### PR TITLE
AppButton.get_caption correctly returns captions of React Native buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 
 
+## [3.0.6] - 21-JUNE-2022
+
+### Fixed
+* `AppButton.get_caption` correctly returns captions of React Native buttons on Android platform where button caption object
+hierarchy is `//android.widget.Button/android.widget.ViewGroup/android.widget.TextView`.
+
+
 ## [3.0.5] - 12-JUNE-2022
 
 ### Fixed

--- a/lib/testcentricity/app_elements/app_element_helper.rb
+++ b/lib/testcentricity/app_elements/app_element_helper.rb
@@ -109,9 +109,19 @@ module TestCentricity
         end
       else
         caption = obj.text
-        if caption.blank? && obj.attribute(:class) == 'android.view.ViewGroup'
-          caption_obj = obj.find_element(:xpath, '//android.widget.TextView')
-          caption = caption_obj.text
+        if caption.blank?
+          case obj.attribute(:class)
+          when 'android.view.ViewGroup'
+            caption_obj = obj.find_element(:xpath, '//android.widget.TextView')
+            caption = caption_obj.text
+          when 'android.widget.Button'
+            caption_obj = obj.find_element(:xpath, '//android.widget.TextView')
+            caption = caption_obj.text
+            if caption.blank?
+              caption_obj = obj.find_element(:xpath, '//android.widget.ViewGroup/android.widget.TextView')
+              caption = caption_obj.text
+            end
+          end
         end
         caption
       end

--- a/lib/testcentricity/version.rb
+++ b/lib/testcentricity/version.rb
@@ -1,3 +1,3 @@
 module TestCentricity
-  VERSION = '3.0.5'
+  VERSION = '3.0.6'
 end


### PR DESCRIPTION
`AppButton.get_caption` correctly returns captions of React Native buttons on Android platform where button caption object hierarchy is `//android.widget.Button/android.widget.ViewGroup/android.widget.TextView`.