### PR TITLE
Fixed AppiumConnect.available_contexts when testing hybrid apps on iOS simulators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 
 
+## [3.1.1] - 04-AUGUST-2022
+
+### Fixed
+* `AppiumConnect.available_contexts` now correctly returns a list of native app and web contexts when testing hybrid apps 
+with WebViews on iOS simulators.
+
+
 ## [3.1.0] - 02-AUGUST-2022
 
 ### Added
@@ -11,7 +18,10 @@ All notable changes to this project will be documented in this file.
 * ### Changed
 * The `WEB_BROWSER` Environment Variable is no longer used to specify the `appium`, `browserstack`, `saucelabs`, `testingbot`,
   or `lambdatest` driver.
-* TestCentricity now supports and integrates with Selenium-Webdriver version 4.3.
+
+### Updated
+* Incorporated all changes from the [TestCentricity™ Web gem](https://rubygems.org/gems/testcentricity_web) version 4.3.0, which is
+  bundled with this gem.
 
 
 ## [3.0.6] - 21-JUNE-2022
@@ -24,7 +34,7 @@ hierarchy is `//android.widget.Button/android.widget.ViewGroup/android.widget.Te
 ## [3.0.5] - 12-JUNE-2022
 
 ### Fixed
-* Fix `gemspec` to no longer include specs and cuke tests as part of deployment package for gem.
+* Fixed `gemspec` to no longer include specs and Cucumber tests as part of deployment package for the gem.
 
 ### Updated
 * Incorporated all changes from the [TestCentricity™ Web gem](https://rubygems.org/gems/testcentricity_web) version 4.2.6, which is

--- a/features/step_definitions/generic_steps.rb
+++ b/features/step_definitions/generic_steps.rb
@@ -73,7 +73,8 @@ When(/^I choose product item (.*) in the products grid$/) do |product_id|
   products_screen.choose_product_item(product_id)
 end
 
-And(/^the shopping cart is (.*)$/) do |state|
+
+Then(/^the shopping cart is (.*)$/) do |state|
   case state.downcase.to_sym
   when :full, :populated
     cart_data_source.load_cart
@@ -82,4 +83,9 @@ And(/^the shopping cart is (.*)$/) do |state|
   else
     raise "#{state} is not a valid selector"
   end
+end
+
+
+When(/^I enter the url for the Apple web site$/) do
+  webview_screen.load_web_site
 end

--- a/features/support/android/screens/web_page_screen.rb
+++ b/features/support/android/screens/web_page_screen.rb
@@ -1,0 +1,10 @@
+class WebPageViewerScreen < BaseAppScreen
+  include SharedWebPageViewerScreen
+
+  trait(:page_name)    { 'Web Page Viewer' }
+  trait(:page_locator) { { accessibility_id: 'webview screen' } }
+
+  # Apple Web Page UI elements
+  elements nav_bar: { xpath: '//nav[@id="ac-globalnav"]' },
+           footer:  { xpath: '//footer[@id="ac-globalfooter"]' }
+end

--- a/features/support/ios/screens/web_page_screen.rb
+++ b/features/support/ios/screens/web_page_screen.rb
@@ -1,0 +1,10 @@
+class WebPageViewerScreen < BaseAppScreen
+  include SharedWebPageViewerScreen
+
+  trait(:page_name)    { 'Web Page Viewer' }
+  trait(:page_locator) { { accessibility_id: 'webview screen' } }
+
+  # Apple Web Page UI elements
+  elements nav_bar: { xpath: '//nav[@id="ac-globalnav"]' },
+           footer:  { xpath: '//footer[@id="ac-globalfooter"]' }
+end

--- a/features/support/shared_components/screens/web_page_screen.rb
+++ b/features/support/shared_components/screens/web_page_screen.rb
@@ -1,0 +1,16 @@
+module SharedWebPageViewerScreen
+  def verify_page_ui
+    sleep(5)
+    super if Environ.is_android?
+    # switch to WebView context
+    AppiumConnect.webview_context
+    # verify Apple home page is loaded
+    ui = {
+      nav_bar => { visible: true },
+      footer  => { visible: true }
+    }
+    verify_ui_states(ui)
+    # return to native app context
+    AppiumConnect.default_context
+  end
+end

--- a/features/support/shared_components/screens/webview_screen.rb
+++ b/features/support/shared_components/screens/webview_screen.rb
@@ -9,4 +9,12 @@ module SharedWebViewScreen
     }
     verify_ui_states(ui)
   end
+
+  def load_web_site
+    url_field.set('https://www.apple.com')
+    go_to_site_button.click
+    sleep(1)
+    go_to_site_button.click if go_to_site_button.visible?
+    self.wait_until_gone(5)
+  end
 end

--- a/features/support/world_pages.rb
+++ b/features/support/world_pages.rb
@@ -14,6 +14,7 @@ module WorldPages
       about_screen:            AboutScreen,
       login_screen:            LoginScreen,
       webview_screen:          WebViewScreen,
+      web_page_screen:         WebPageViewerScreen,
       products_screen:         ProductsScreen,
       product_item_screen:     ProductItemScreen,
       cart_screen:             CartScreen,

--- a/features/webview.feature
+++ b/features/webview.feature
@@ -1,0 +1,14 @@
+@mobile @ios @android @regression
+
+
+Feature:  Verify WebView
+  In order to ensure that hybrid WebViews are supported
+  As a developer of the TestCentricity gem
+  I expect to be able to validate that web content is loaded into a hybrid WebView
+
+
+  Scenario:  Verify hybrid WebView
+    Given I have launched the SauceLabs My Demo app
+    And I am on the Webview screen
+    When I enter the url for the Apple web site
+    Then I expect the Web Page Viewer screen to be correctly displayed

--- a/lib/testcentricity/app_core/appium_connect_helper.rb
+++ b/lib/testcentricity/app_core/appium_connect_helper.rb
@@ -190,7 +190,7 @@ module TestCentricity
     end
 
     def self.webview_context
-      contexts = available_contexts
+      contexts = $driver.available_contexts
       puts "Contexts = #{contexts}" if ENV['DEBUG']
       set_context(contexts.last)
       puts "Current context = #{$driver.current_context}" if ENV['DEBUG']
@@ -282,6 +282,7 @@ module TestCentricity
         caps[:xcodeSigningId] = ENV['TEAM_NAME'] if ENV['TEAM_NAME']
         caps[:appActivity] = ENV['APP_ACTIVITY'] if ENV['APP_ACTIVITY']
         caps[:appPackage] = ENV['APP_PACKAGE'] if ENV['APP_PACKAGE']
+        caps[:webviewConnectTimeout] = '90000'
 
         if ENV['BUNDLE_ID']
           caps[:bundleId] = ENV['BUNDLE_ID']

--- a/lib/testcentricity/version.rb
+++ b/lib/testcentricity/version.rb
@@ -1,3 +1,3 @@
 module TestCentricity
-  VERSION = '3.1.0'
+  VERSION = '3.1.1'
 end


### PR DESCRIPTION
* `AppiumConnect.available_contexts` now correctly returns a list of native app and web contexts when testing hybrid apps with WebViews on iOS simulators.
* Added cuke tests and supporting strep defs, page objects, and methods for testing verification of WebViews.